### PR TITLE
Update the gemspec

### DIFF
--- a/puma-plugin-systemd.gemspec
+++ b/puma-plugin-systemd.gemspec
@@ -1,19 +1,19 @@
 Gem::Specification.new do |spec|
   spec.name     = "puma-plugin-systemd"
-  spec.version  = "0.1.1"
-  spec.author   = "Samuel Cochran"
-  spec.email    = "sj26@sj26.com"
+  spec.version  = "1.0.0"
+  spec.author   = "Scott Knight"
+  spec.email    = "scott.knight@parentsquare.com"
 
   spec.summary  = "Puma integration with systemd: notify, status, watchdog"
-  spec.homepage = "https://github.com/sj26/puma-plugin-systemd"
+  spec.homepage = "https://github.com/ParentSquare/puma-plugin-systemd"
   spec.license  = "MIT"
 
   spec.files = Dir["lib/**/*.rb", "README.md", "LICENSE"]
 
-  spec.add_runtime_dependency "puma", ">= 3.6", "< 5"
+  spec.add_runtime_dependency "puma", ">= 5.0"
   spec.add_runtime_dependency "json"
 
-  spec.add_development_dependency "bundler", "~> 1.13"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end

--- a/puma-plugin-systemd.gemspec
+++ b/puma-plugin-systemd.gemspec
@@ -10,10 +10,10 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["lib/**/*.rb", "README.md", "LICENSE"]
 
-  spec.add_runtime_dependency "puma", ">= 5.0"
+  spec.add_runtime_dependency "puma", ">= 3.6", "< 6"
   spec.add_runtime_dependency "json"
 
-  spec.add_development_dependency "bundler", "~> 1.17"
-  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end

--- a/puma-plugin-systemd.gemspec
+++ b/puma-plugin-systemd.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "puma", ">= 5.0"
   spec.add_runtime_dependency "json"
 
-  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end


### PR DESCRIPTION
Updated the gemspec to use currently available gems and metadata to help with story PDEV-640-upgrade-puma. This particular gem was not allowing me to upgrade puma to v5. When v5.1 is released we wont need this gem anymore.