### PR TITLE
PDEV640 v1.0.1

### DIFF
--- a/lib/puma/plugin/systemd.rb
+++ b/lib/puma/plugin/systemd.rb
@@ -161,12 +161,6 @@ Puma::Plugin.create do
     end
   end
 
-  # Puma creates the plugin when encountering `plugin` in the config.
-  def initialize(loader)
-    # This is a Puma::PluginLoader
-    @loader = loader
-  end
-
   # We can start doing something when we have a launcher:
   def start(launcher)
     @launcher = launcher

--- a/puma-plugin-systemd.gemspec
+++ b/puma-plugin-systemd.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name     = "puma-plugin-systemd"
-  spec.version  = "1.0.0"
+  spec.version  = "1.0.1"
   spec.author   = "Scott Knight"
   spec.email    = "scott.knight@parentsquare.com"
 
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "puma", ">= 3.6", "< 6"
   spec.add_runtime_dependency "json"
 
-  spec.add_development_dependency "bundler", "~> 1.13"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.0"
 end


### PR DESCRIPTION
Removed the initialization method for Puma 5 compatibility. We are no longer supporting older versions of Puma. I also removed specific versions for dependencies which should alleviate gem install issues.