### PR TITLE
PDEV640 v1.0.2

### DIFF
--- a/lib/puma/plugin/systemd.rb
+++ b/lib/puma/plugin/systemd.rb
@@ -125,30 +125,30 @@ Puma::Plugin.create do
     end
 
     def clustered?
-      stats.has_key? "workers"
+      @stats.has_key? "workers"
     end
 
     def workers
-      stats.fetch("workers", 1)
+      @stats.fetch("workers", 1)
     end
 
     def booted_workers
-      stats.fetch("booted_workers", 1)
+      @stats.fetch("booted_workers", 1)
     end
 
     def running
       if clustered?
-        stats["worker_status"].map { |s| s["last_status"].fetch("running", 0) }.inject(0, &:+)
+        @stats["worker_status"].map { |s| s["last_status"].fetch("running", 0) }.inject(0, &:+)
       else
-        stats.fetch("running", 0)
+        @stats.fetch("running", 0)
       end
     end
 
     def backlog
       if clustered?
-        stats["worker_status"].map { |s| s["last_status"].fetch("backlog", 0) }.inject(0, &:+)
+        @stats["worker_status"].map { |s| s["last_status"].fetch("backlog", 0) }.inject(0, &:+)
       else
-        stats.fetch("backlog", 0)
+        @stats.fetch("backlog", 0)
       end
     end
 

--- a/puma-plugin-systemd.gemspec
+++ b/puma-plugin-systemd.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["lib/**/*.rb", "README.md", "LICENSE"]
 
-  spec.add_runtime_dependency "puma", "~> 3.6"
+  spec.add_runtime_dependency "puma", ">= 3.6", "< 5"
   spec.add_runtime_dependency "json"
 
   spec.add_development_dependency "bundler", "~> 1.13"


### PR DESCRIPTION
Updates the fetch_stats method. @launcher.stats now returns a hash rather than json. This update changes the hash to json, then allows JSON to parse it, ensuring all keys are string based for the Stats class.